### PR TITLE
Update links to CWLS.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 
     ```sh
-        $pip insatll las-py
+        $pip install las-py
     ```
 
 - Usage

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## las-py is a zero-dependency Python library for parsing .Las file (Geophysical/Canadian well log files).
 
-## Currently supports only version 2.0 of LAS Specification. For more information about this format, see the Canadian Well Logging Society [web page](http://www.cwls.org/las/)
+## Currently supports only version 2.0 of [LAS Specification](https://www.cwls.org/wp-content/uploads/2017/02/Las2_Update_Feb2017.pdf). For more information about this format, see the Canadian Well Logging Society [product page](https://www.cwls.org/products//)
 
 - What's new in 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## las-py is a zero-dependency Python library for parsing .Las file (Geophysical/Canadian well log files).
 
-## Currently supports only version 2.0 of [LAS Specification](https://www.cwls.org/wp-content/uploads/2017/02/Las2_Update_Feb2017.pdf). For more information about this format, see the Canadian Well Logging Society [product page](https://www.cwls.org/products//)
+## Currently supports only version 2.0 of [LAS Specification](https://www.cwls.org/wp-content/uploads/2017/02/Las2_Update_Feb2017.pdf). For more information about this format, see the Canadian Well Logging Society [product page](https://www.cwls.org/products/)
 
 - What's new in 1.1.0
 


### PR DESCRIPTION
The previous link reports: 'Not Found on the cwls.org site.

This pull request has these changes:
- Update the links to cwls.org to use https instead of http.
- Add link directly to the version 2.0 specification.
- Update the previous 'las' link to go the 'product' page where the LAS specifications and tool information is.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC